### PR TITLE
(AdoptOpenJDK) Wording and switch cleanup

### DIFF
--- a/AdoptOpenJDK/README.tmp
+++ b/AdoptOpenJDK/README.tmp
@@ -21,8 +21,6 @@
 ** Note: FeatureOracleJavaSoft can be used to prevent Oracle Java launching from PATH when AdoptOpenJDK is uninstalled. Reinstall Oracle Java if you need to restore the Oracle registry keys. **
 
 Optional parameters can be used that group some of the features together:
-These are the preferred Install Levels to pass via params
-Example: `choco install <PackageName> --params="/INSTALLLEVEL=2"'
 
 | Parameter | Features |
 |----|----|
@@ -31,6 +29,8 @@ Example: `choco install <PackageName> --params="/INSTALLLEVEL=2"'
 | &nbsp; INSTALLLEVEL=2 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,<br/> FeatureJavaHome,FeatureIcedTeaWeb &nbsp; |
 |----|----|
 | &nbsp; INSTALLLEVEL=3 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,<br/> FeatureJavaHome,FeatureIcedTeaWeb,FeatureJNLPFileRunWith &nbsp; |
+
+Example: `choco install <PackageName> --params="/INSTALLLEVEL=2"'
 
 The following example silently installs AdoptOpenJDK, updates the PATH, associates .jar files with Java applications and defines JAVA_HOME:
 Example: `choco install <PackageName> --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome /INSTALLDIR=c:\Program Files\AdoptOpenJDK\ /quiet"`

--- a/AdoptOpenJDK/README.tmp
+++ b/AdoptOpenJDK/README.tmp
@@ -21,6 +21,8 @@
 ** Note: FeatureOracleJavaSoft can be used to prevent Oracle Java launching from PATH when AdoptOpenJDK is uninstalled. Reinstall Oracle Java if you need to restore the Oracle registry keys. **
 
 Optional parameters can be used that group some of the features together:
+These are the preferred Install Levels to pass via params
+Example: `choco install <PackageName> --params="/INSTALLLEVEL=2"'
 
 | Parameter | Features |
 |----|----|
@@ -31,7 +33,7 @@ Optional parameters can be used that group some of the features together:
 | &nbsp; INSTALLLEVEL=3 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,<br/> FeatureJavaHome,FeatureIcedTeaWeb,FeatureJNLPFileRunWith &nbsp; |
 
 The following example silently installs AdoptOpenJDK, updates the PATH, associates .jar files with Java applications and defines JAVA_HOME:
-Example: `choco install <PackageName> --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome INSTALLDIR=c:\Program Files\AdoptOpenJDK\ /quiet"`
+Example: `choco install <PackageName> --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome /INSTALLDIR=c:\Program Files\AdoptOpenJDK\ /quiet"`
 ** Note: You must use INSTALLDIR with FeatureMain. INSTALLDIR Default is `%Programfiles%\AdoptOpenJDK` **
 
 This will install both the 32 bit and 64 bit versions of the desired package by using the parameter `/both`

--- a/AdoptOpenJDK/tools/helper.ps1
+++ b/AdoptOpenJDK/tools/helper.ps1
@@ -17,17 +17,20 @@ param(
 $New_pp = @{}; $toolsDir = "${env:ProgramFiles}\AdoptOpenJDK"
 	if ([string]::IsNullOrEmpty($pp.quiet)) {
 		$New_pp.add( "/quiet", $true )
+	} else {
+	# Added to make sure the /quiet silent install is carried over if the user adds it to the params switch list
+		$New_pp.add( "/quiet", $true )
 	}
 	if (![string]::IsNullOrEmpty($pp.transforms)) {
-		$New_pp.add( "/transforms", $pp.transforms )
+		$New_pp.add( "transforms", $pp.transforms )
 	}
     if (![string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
 	    Write-Warning "You must use INSTALLDIR with FeatureMain."
         Write-Warning "Using provided $($pp.INSTALLDIR)"
-        $New_pp.add( "/InstallDir", $pp.INSTALLDIR )
+        $New_pp.add( "InstallDir", $pp.INSTALLDIR )
     } elseif ([string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) { 
 	    Write-Warning "Using Default of $toolsDir"
-	    $New_pp.add( "/InstallDir", "$toolsDir" )
+	    $New_pp.add( "InstallDir", "$toolsDir" )
     }
 	if ((![string]::IsNullOrEmpty($pp.ADDLOCAL)) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
         Write-Warning "Using Addlocal"
@@ -55,7 +58,7 @@ $New_pp = @{}; $toolsDir = "${env:ProgramFiles}\AdoptOpenJDK"
             }
         }
         Write-Warning "No InstallLevel detected. Defaulting to AddLocal"
-	    $New_pp.add( "/ADDLOCAL", ($pp_addlocal_array -replace ".{1}$") )
+	    $New_pp.add( "ADDLOCAL", ($pp_addlocal_array -replace ".{1}$") )
 
 	}
 	if (![string]::IsNullOrEmpty($pp.INSTALLLEVEL) ) {

--- a/AdoptOpenJDK/tools/helper.ps1
+++ b/AdoptOpenJDK/tools/helper.ps1
@@ -4,9 +4,9 @@ Update-TypeData -TypeName System.Collections.HashTable `
     -MemberType ScriptMethod `
     -MemberName ToString `
     -Value { $keys = $this.keys; foreach ($key in $keys) { $v = $this[$key]; 
-             if ($key -match "\s") { $hashstr += "`"$key`"" + "=" + "`"$v`"" + ";" }
-             else { $hashstr += $key + "=" + "`"$v`"" + ";" } };
-             return $hashstr }
+    if ($key -match "\s") { $hashstr += "`"$key`"" + "=" + "`"$v`"" + ";" }
+    else { $hashstr += $key + "=" + "`"$v`"" + ";" } };
+    return $hashstr }
 <# Eol Updating of hashtable to string for ToString method #>
 
 function Test-PackageParamaters {
@@ -15,55 +15,53 @@ param(
     [hashtable]$pp
 )
 $New_pp = @{}; $toolsDir = "${env:ProgramFiles}\AdoptOpenJDK"
-	if ([string]::IsNullOrEmpty($pp.quiet)) {
-		$New_pp.add( "/quiet", $true )
-	} else {
-	# Added to make sure the /quiet silent install is carried over if the user adds it to the params switch list
-		$New_pp.add( "/quiet", $true )
-	}
-	if (![string]::IsNullOrEmpty($pp.transforms)) {
-		$New_pp.add( "transforms", $pp.transforms )
-	}
-    if (![string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
-	    Write-Warning "You must use INSTALLDIR with FeatureMain."
-        Write-Warning "Using provided $($pp.INSTALLDIR)"
-        $New_pp.add( "InstallDir", $pp.INSTALLDIR )
-    } elseif ([string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) { 
-	    Write-Warning "Using Default of $toolsDir"
-	    $New_pp.add( "InstallDir", "$toolsDir" )
+    if (![string]::IsNullOrEmpty($pp.transforms)) {
+      $New_pp.add( "transforms", $pp.transforms )
     }
-	if ((![string]::IsNullOrEmpty($pp.ADDLOCAL)) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
-        Write-Warning "Using Addlocal"
-        $addlocalArray = ($pp.ADDLOCAL -split "\,")
-        foreach ( $_ in $addlocalArray)  {
-	        switch -Wildcard ($_) {
-                "FeatureMain" {
-                    $pp_addlocal_array += -join ("FeatureMain", ",")
-                }
-                "FeatureEnvironment" {
-                    $pp_addlocal_array += -join ("FeatureEnvironment", ",")
-                }
-                "FeatureJarFileRunWith" {
-                    $pp_addlocal_array += -join ("FeatureJarFileRunWith", ",")
-                }
-                "FeatureJavaHome" {
-                    $pp_addlocal_array += -join ("FeatureJavaHome", ",")
-                }
-                "FeatureIcedTeaWeb" {
-                    $pp_addlocal_array += -join ("FeatureIcedTeaWeb", ",")
-                }
-                "FeatureJNLPFileRunWith" {
-                    $pp_addlocal_array += -join ("FeatureJNLPFileRunWith", ",")
-                }
-            }
+    if (![string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
+      Write-Warning "You must use INSTALLDIR with FeatureMain."
+      Write-Warning "Using provided $($pp.INSTALLDIR)"
+      $New_pp.add( "InstallDir", """$($pp.INSTALLDIR)""" )
+    } elseif ([string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) { 
+      Write-Warning "Using Default of $toolsDir"
+      $New_pp.add( "InstallDir", """$toolsDir""" )
+    }
+    if ((![string]::IsNullOrEmpty($pp.ADDLOCAL)) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
+      Write-Warning "Using Addlocal"
+      $addlocalArray = ($pp.ADDLOCAL -split "\,")
+      foreach ( $_ in $addlocalArray)  {
+        switch -Wildcard ($_) {
+          "FeatureMain" {
+            $pp_addlocal_array += -join ("FeatureMain", ",")
+          }
+          "FeatureEnvironment" {
+            $pp_addlocal_array += -join ("FeatureEnvironment", ",")
+          }
+          "FeatureJarFileRunWith" {
+            $pp_addlocal_array += -join ("FeatureJarFileRunWith", ",")
+          }
+          "FeatureJavaHome" {
+            $pp_addlocal_array += -join ("FeatureJavaHome", ",")
+          }
+          "FeatureIcedTeaWeb" {
+            $pp_addlocal_array += -join ("FeatureIcedTeaWeb", ",")
+          }
+          "FeatureJNLPFileRunWith" {
+            $pp_addlocal_array += -join ("FeatureJNLPFileRunWith", ",")
+          }
         }
-        Write-Warning "No InstallLevel detected. Defaulting to AddLocal"
-	    $New_pp.add( "ADDLOCAL", ($pp_addlocal_array -replace ".{1}$") )
-
-	}
-	if (![string]::IsNullOrEmpty($pp.INSTALLLEVEL) ) {
-		$New_pp.add( "INSTALLLEVEL", $pp.INSTALLLEVEL )
-	}
-
+      }
+      Write-Warning "No InstallLevel detected. Defaulting to AddLocal"
+      $New_pp.add( "ADDLOCAL", ($pp_addlocal_array -replace ".{1}$") )
+    }
+    if (![string]::IsNullOrEmpty($pp.INSTALLLEVEL) ) {
+       $New_pp.add( "INSTALLLEVEL", $pp.INSTALLLEVEL )
+    }
+    if ([string]::IsNullOrEmpty($pp.quiet)) {
+      $New_pp.add( "/quiet", $true )
+    } else {
+      # Added to make sure the /quiet silent install is carried over if the user adds it to the params switch list
+      $New_pp.add( "/quiet", $true )
+    }
 return $New_pp
 }


### PR DESCRIPTION
@johanjanssen @johanjanssen-sanoma 
The following are changes that need to be made to the wording of the readme. The changes to the switches to work correctly all the time.

I have looked into an issue related to #7 and filed it [here](https://github.com/AdoptOpenJDK/openjdk-installer/issues/223)
This issue makes the example even on AdoptOpenJDK website not work correctly. I feel that due to this issue a preferred method of using the `INSTALLLEVEL` is recommended.

Thanks for looking into this PR.
