### PR TITLE
(adoptopenjdk) Update to fix issue with custom install folder

### DIFF
--- a/AdoptOpenJDK/README.tmp
+++ b/AdoptOpenJDK/README.tmp
@@ -26,14 +26,12 @@ Optional parameters can be used that group some of the features together:
 |----|----|
 | &nbsp; INSTALLLEVEL=1 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith &nbsp; |
 |----|----|
-| &nbsp; INSTALLLEVEL=2 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,<br/> FeatureJavaHome,FeatureIcedTeaWeb &nbsp; |
+| &nbsp; INSTALLLEVEL=2 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith, FeatureJavaHome,FeatureIcedTeaWeb &nbsp; |
 |----|----|
-| &nbsp; INSTALLLEVEL=3 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,<br/> FeatureJavaHome,FeatureIcedTeaWeb,FeatureJNLPFileRunWith &nbsp; |
-
-Example: `choco install <PackageName> --params="/INSTALLLEVEL=2"'
+| &nbsp; INSTALLLEVEL=3 &nbsp; | &nbsp; FeatureMain,FeatureEnvironment,FeatureJarFileRunWith, FeatureJavaHome,FeatureIcedTeaWeb,FeatureJNLPFileRunWith &nbsp; |
 
 The following example silently installs AdoptOpenJDK, updates the PATH, associates .jar files with Java applications and defines JAVA_HOME:
-Example: `choco install <PackageName> --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome /INSTALLDIR=c:\Program Files\AdoptOpenJDK\ /quiet"`
+Example: `choco install <PackageName> --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome /INSTALLDIR=C:\Program Files\AdoptOpenJDK\ /quiet"`
 ** Note: You must use INSTALLDIR with FeatureMain. INSTALLDIR Default is `%Programfiles%\AdoptOpenJDK` **
 
 This will install both the 32 bit and 64 bit versions of the desired package by using the parameter `/both`

--- a/AdoptOpenJDK/install32.ps1
+++ b/AdoptOpenJDK/install32.ps1
@@ -3,19 +3,18 @@ $ErrorActionPreference  = 'Stop'
 . "$PSScriptRoot\helper.ps1"
 
 # Get Package Parameters
-$toolsDir = @{$true="${env:ProgramFiles}\AdoptOpenJDK";$false="${env:programfiles(x86)}\AdoptOpenJDK"}[ ((Get-OSArchitectureWidth 64) -or ($env:chocolateyForceX86 -eq $true)) ]
-$parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameters ).ToString() -replace('"|="True"','') -replace(";", ' ') -replace("==", '=')
+$parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameters ).ToString() -replace('""|="True"','') -replace(";", ' ') -replace("==", '=')
 
 $packageArgs = @{
-  PackageName = ''
-  fileType = ''
-  Url = ''
-  Url64bit = ''
-  Checksum = ''
-  ChecksumType = ''
-  Checksum64 = ''
-  ChecksumType64 = ''
-  SilentArgs = "$pp"
+  PackageName     = ''
+  fileType        = ''
+  Url             = ''
+  Url64bit        = ''
+  Checksum        = ''
+  ChecksumType    = ''
+  Checksum64      = ''
+  ChecksumType64  = ''
+  SilentArgs      = $pp
 }
 
 if ($parameters.both){

--- a/AdoptOpenJDK/install64.ps1
+++ b/AdoptOpenJDK/install64.ps1
@@ -3,16 +3,15 @@ $ErrorActionPreference  = 'Stop'
 . "$PSScriptRoot\helper.ps1"
 
 # Get Package Parameters
-$toolsDir = @{$true="${env:ProgramFiles}\AdoptOpenJDK";$false="${env:programfiles(x86)}\AdoptOpenJDK"}[ ((Get-OSArchitectureWidth 64) -or ($env:chocolateyForceX86 -eq $true)) ]
-$parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameters ).ToString() -replace('"|="True"','') -replace(";", ' ') -replace("==", '=')
+$parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameters ).ToString() -replace('""|="True"','') -replace(";", ' ') -replace("==", '=')
 
 $packageArgs = @{
-  PackageName = ''
-  Url64bit = ''
-  Checksum64 = ''
+  PackageName    = ''
+  Url64bit       = ''
+  Checksum64     = ''
   ChecksumType64 = ''
-  fileType      = ''
-  SilentArgs = "$pp"
+  fileType       = ''
+  SilentArgs     = $pp
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/AdoptOpenJDK/tools/helper.ps1
+++ b/AdoptOpenJDK/tools/helper.ps1
@@ -4,9 +4,9 @@ Update-TypeData -TypeName System.Collections.HashTable `
     -MemberType ScriptMethod `
     -MemberName ToString `
     -Value { $keys = $this.keys; foreach ($key in $keys) { $v = $this[$key]; 
-    if ($key -match "\s") { $hashstr += "`"$key`"" + "=" + "`"$v`"" + ";" }
-    else { $hashstr += $key + "=" + "`"$v`"" + ";" } };
-    return $hashstr }
+             if ($key -match "\s") { $hashstr += "`"$key`"" + "=" + "`"$v`"" + ";" }
+             else { $hashstr += $key + "=" + "`"$v`"" + ";" } };
+             return $hashstr }
 <# Eol Updating of hashtable to string for ToString method #>
 
 function Test-PackageParamaters {
@@ -14,17 +14,18 @@ function Test-PackageParamaters {
 param(
     [hashtable]$pp
 )
-$New_pp = @{}; $toolsDir = "${env:ProgramFiles}\AdoptOpenJDK"
+$New_pp = @{}; 
+$toolsDir = @{$true="${env:ProgramFiles}\AdoptOpenJDK";$false="${env:programfiles(x86)}\AdoptOpenJDK"}[ ((Get-OSArchitectureWidth 64) -or ($env:chocolateyForceX86 -eq $true)) ]
     if (![string]::IsNullOrEmpty($pp.transforms)) {
       $New_pp.add( "transforms", $pp.transforms )
     }
     if (![string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
       Write-Warning "You must use INSTALLDIR with FeatureMain."
       Write-Warning "Using provided $($pp.INSTALLDIR)"
-      $New_pp.add( "InstallDir", """$($pp.INSTALLDIR)""" )
+      $New_pp.add( "InstallDir", "`"`"$($pp.INSTALLDIR)`"`"" )
     } elseif ([string]::IsNullOrEmpty($pp.INSTALLDIR) -and (($New_pp.ADDLOCAL -match "FeatureMain") -or ($pp.ADDLOCAL -match "FeatureMain")) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) { 
       Write-Warning "Using Default of $toolsDir"
-      $New_pp.add( "InstallDir", """$toolsDir""" )
+      $New_pp.add( "InstallDir", "`"`"$toolsDir`"`"" )
     }
     if ((![string]::IsNullOrEmpty($pp.ADDLOCAL)) -and ([string]::IsNullOrEmpty($pp.INSTALLLEVEL)) ) {
       Write-Warning "Using Addlocal"
@@ -63,5 +64,6 @@ $New_pp = @{}; $toolsDir = "${env:ProgramFiles}\AdoptOpenJDK"
       # Added to make sure the /quiet silent install is carried over if the user adds it to the params switch list
       $New_pp.add( "/quiet", $true )
     }
+
 return $New_pp
 }

--- a/AdoptOpenJDK/update.ps1
+++ b/AdoptOpenJDK/update.ps1
@@ -22,31 +22,33 @@ function global:au_SearchReplace {
   if ( [string]::IsNullOrEmpty($Latest.URL32) ) {
 		@{
 			".\tools\chocolateyinstall.ps1" = @{
-				"(?i)(^\s*PackageName\s*=\s*)('.*')" = "`$1'$($Latest.PackageName)'"
-				"(?i)(^\s*url64bit\s*=\s*)('.*')"	= "`$1'$($Latest.URL64)'"
-				"(?i)(^\s*Checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
-				"(?i)(^\s*ChecksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
+				"(?i)(^\s*PackageName\s*=\s*)('.*')"           = "`$1'$($Latest.PackageName)'"
+				"(?i)(^\s*fileType\s*=\s*)('.*')"              = "`$1'$($Latest.fileType)'"
+				"(?i)(^\s*url64bit\s*=\s*)('.*')"              = "`$1'$($Latest.URL64)'"
+				"(?i)(^\s*Checksum64\s*=\s*)('.*')"            = "`$1'$($Latest.Checksum64)'"
+				"(?i)(^\s*ChecksumType64\s*=\s*)('.*')"        = "`$1'$($Latest.ChecksumType64)'"
 			}
 			".\adoptopenjdk.nuspec" = @{
-				"(?i)(^\s*\<title\>).*(\<\/title\>)" = "`${1}$($Latest.Title)`${2}"
-				"(?i)(^\s*\<summary\>).*(\<\/summary\>)" = "`${1}$($Latest.summary)`${2}"
+				"(?i)(^\s*\<title\>).*(\<\/title\>)"           = "`${1}$($Latest.Title)`${2}"
+				"(?i)(^\s*\<summary\>).*(\<\/summary\>)"       = "`${1}$($Latest.summary)`${2}"
 				"(?i)(^\s*\<licenseUrl\>).*(\<\/licenseUrl\>)" = "`${1}$($Latest.LicenseUrl)`${2}"
 			}
 		}
 	} else {
 		@{
 			".\tools\chocolateyinstall.ps1" = @{
-				"(?i)(^\s*PackageName\s*=\s*)('.*')" = "`$1'$($Latest.PackageName)'"
-				"(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
-				"(?i)(^\s*url64bit\s*=\s*)('.*')"	= "`$1'$($Latest.URL64)'"
-				"(?i)(^\s*Checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
-				"(?i)(^\s*ChecksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
-				"(?i)(^\s*Checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
-				"(?i)(^\s*ChecksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
+				"(?i)(^\s*PackageName\s*=\s*)('.*')"           = "`$1'$($Latest.PackageName)'"
+				"(?i)(^\s*fileType\s*=\s*)('.*')"              = "`$1'$($Latest.fileType)'"
+				"(?i)(^\s*url\s*=\s*)('.*')"                   = "`$1'$($Latest.URL32)'"
+				"(?i)(^\s*url64bit\s*=\s*)('.*')"              = "`$1'$($Latest.URL64)'"
+				"(?i)(^\s*Checksum\s*=\s*)('.*')"              = "`$1'$($Latest.Checksum32)'"
+				"(?i)(^\s*ChecksumType\s*=\s*)('.*')"          = "`$1'$($Latest.ChecksumType32)'"
+				"(?i)(^\s*Checksum64\s*=\s*)('.*')"            = "`$1'$($Latest.Checksum64)'"
+				"(?i)(^\s*ChecksumType64\s*=\s*)('.*')"        = "`$1'$($Latest.ChecksumType64)'"
 			}
 			".\adoptopenjdk.nuspec" = @{
-				"(?i)(^\s*\<title\>).*(\<\/title\>)" = "`${1}$($Latest.Title)`${2}"
-				"(?i)(^\s*\<summary\>).*(\<\/summary\>)" = "`${1}$($Latest.summary)`${2}"
+				"(?i)(^\s*\<title\>).*(\<\/title\>)"           = "`${1}$($Latest.Title)`${2}"
+				"(?i)(^\s*\<summary\>).*(\<\/summary\>)"       = "`${1}$($Latest.summary)`${2}"
 				"(?i)(^\s*\<licenseUrl\>).*(\<\/licenseUrl\>)" = "`${1}$($Latest.LicenseUrl)`${2}"
 			}
 		}
@@ -76,8 +78,9 @@ param(
 [string]$project = "jdk",
 [ValidateSet("large", "normal")]
 [string]$heap_size = "normal",
-[string]$dev_name, # orginal package name
-[switch]$ext # optional switch
+[string]$dev_name,     # orginal package name
+[switch]$ext,          # optional switch for extensions
+[switch]$fixedversion  # optional switch for fixedversion
 )
 $me = ( $MyInvocation.MyCommand );
 # Depending on the $arch used above determines which string is used in the call to the server
@@ -118,13 +121,18 @@ $JavaVM = @{$true = "${type}${number}"; $false = "${type}${number}-${jvm}" }[ ( 
 $PackageName = @{$true = "AdoptOpenJDK-${JavaVM}"; $false = "${dev_name}" }[ ( $dev_name -eq "" ) ]
 if ($url32 -match "${number}U") { $url32 = $url32 } else { $url32 = $null }
 Write-Verbose "$me url32 -$url32- url64 -$url64-"
+if ($fixedVersion) {
+  $packageVersion =  $beta
+} else {
+  $packageVersion = Get-FixVersion $beta
+}
 
 	@{
         Title           = "AdoptOpenJDK ${type}${number} ${jvm} ${version}"
         PackageName     = $PackageName
         URL32           = $url32
         URL64           = $url64
-        Version         = $beta
+        Version         = $packageVersion
         LicenseUrl      = "https://github.com/AdoptOpenJDK/openjdk-jdk${number}u/blob/master/LICENSE"
         SemVer          = $vest
         fileType        = $fileType

--- a/AdoptOpenJDK/update_helper.ps1
+++ b/AdoptOpenJDK/update_helper.ps1
@@ -180,9 +180,11 @@ $number = ($major, $year, $month, $day) -join "."
 Write-Verbose "$me Using ea versioning number -$number-"
 } elseif ((![string]::IsNullOrEmpty($major) ) -and (![string]::IsNullOrEmpty($minor) ) -and (![string]::IsNullOrEmpty($patch) )) {
 Write-Verbose "$me B major -$major- minor -$minor- patch -$patch-"
+<# BOL Fix for the Current Issue of Version 8 Builds on Chocolatey #>
 if (( $major -eq "8" )) { $minor = $minor+$patch; $patch = $null
     Write-Verbose "$me Detected major as 8 correcting to bad version";
     Write-Verbose "$me B1 Major -$major- Minor -$minor- patch -$patch-" }
+<# EOL Fix for the Current Issue of Version 8 Builds on Chocolatey #>
 $number = ($major, $minor, $patch) -join "."
 Write-Verbose "$me Using semver versioning number -$number-"
 } else {
@@ -230,7 +232,7 @@ $data = $data  -replace( "<$item>" , $($new_info[$i]) )
 $i++
 }
 
-Write-Verbose "data -$data-"
+Write-Verbose "$me data -$data-"
 $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
 [System.IO.File]::WriteAllLines("$pwd/README.md", $data, $Utf8NoBomEncoding)
 


### PR DESCRIPTION
@johanjanssen @johanjanssen-sanoma 
This will fix the issue of not being able to customize the `InstallDir`. This was caused by a `-replace` command that was a tad over replacing. This also fixes issue #13 with the empty `FileType` for the `chocolateyinstall.ps1` files.

This should make it work like @rgl would like in issue #12 